### PR TITLE
Update required tools

### DIFF
--- a/src/ring_middleware_logging/log_wrappers.clj
+++ b/src/ring_middleware_logging/log_wrappers.clj
@@ -1,5 +1,6 @@
 (ns ring-middleware-logging.log-wrappers
-  (:require [clojure.tools.logging :as log])
+  (:require [clojure.tools.logging :as log]
+            [clojure.stacktrace])
   (:import (java.util UUID)))
 
 (defn exception-logging


### PR DESCRIPTION
Adding this library to a project that doesn't explicitly require the clojure.stacktrace is causing a problem at compile time due to the missing java class for the stacktrace.

I am adding this requirement directly in this library to avoid missing dependencies errors in the future for other projects.